### PR TITLE
Metallic Bottle: use a slightly darker background color for selections

### DIFF
--- a/colorschemes/metallic-bottle.conf
+++ b/colorschemes/metallic-bottle.conf
@@ -32,7 +32,7 @@ error=#fff;#843121;false;true
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=#000;#c48c65;false;true
+selection=#000;#ebdfd8;false;true
 current_line=#000;#fff;true
 brace_good=#757c75;;true;false
 brace_bad=#843121;;true;false
@@ -92,7 +92,7 @@ scalar=string_2
 label=default,bold
 preprocessor=#c48c65
 regex=number_1
-operator=#d0c096
+operator=#816e40
 decorator=string_1,bold
 other=#c48c65
 


### PR DESCRIPTION
I just made the background color for selections a little darker so that it is different from the foreground color.

Closes #70.

![Screenshot](https://github.com/geany/geany-themes/assets/617017/472e0715-c1c1-4166-926e-b2260d160687)
